### PR TITLE
fixed lazy render in Whether

### DIFF
--- a/src/Whether.js
+++ b/src/Whether.js
@@ -12,8 +12,8 @@ const renderElement = element => (typeof element === 'function' ? element() : el
 
 const Whether = ({context, matches, children}) => {
     const childrenCount = Children.count(children);
-    const firstChild = childrenCount === 1 ? children : children[0];
-    const lastChild = childrenCount === 1 ? children : children[children.length - 1];
+    const firstChild = childrenCount <= 1 ? children : children[0];
+    const lastChild = childrenCount <= 1 ? children : children[children.length - 1];
     const elseChild = lastChild.type === Else ? lastChild : null;
 
     if (typeof matches === 'boolean') {


### PR DESCRIPTION
修复在 Whether 组件中，如果使用 function 作为 children 以使用 lazy render 时，由于 React.Children.count 返回 0 而报错的问题。